### PR TITLE
Mark mounting points as private

### DIFF
--- a/userspace/ksud/src/defs.rs
+++ b/userspace/ksud/src/defs.rs
@@ -17,16 +17,17 @@ pub const MAGISKBOOT_PATH: &str = concatcp!(BINARY_DIR, "magiskboot");
 #[cfg(target_os = "android")]
 pub const DAEMON_LINK_PATH: &str = concatcp!(BINARY_DIR, "ksud");
 
-pub const MODULE_DIR: &str = concatcp!(ADB_DIR, "modules/");
+pub const MODULE_DIR: &str = concatcp!(ADB_DIR, "modules");
 pub const MODULE_IMG: &str = concatcp!(WORKING_DIR, "modules.img");
 pub const MODULE_UPDATE_IMG: &str = concatcp!(WORKING_DIR, "modules_update.img");
+pub const MOUNT_MODULE_DIR: &str = "/apex/modules";
 
 pub const MODULE_UPDATE_TMP_IMG: &str = concatcp!(WORKING_DIR, "update_tmp.img");
 
 // warning: this directory should not change, or you need to change the code in module_installer.sh!!!
 pub const MODULE_UPDATE_TMP_DIR: &str = concatcp!(ADB_DIR, "modules_update/");
 
-pub const SYSTEM_RW_DIR: &str = concatcp!(MODULE_DIR, ".rw/");
+pub const SYSTEM_RW_DIR: &str = concatcp!(MODULE_DIR, "/.rw/");
 
 pub const TEMP_DIR: &str = "/apex/debug_ramdisk";
 pub const MODULE_WEB_DIR: &str = "webroot";

--- a/userspace/ksud/src/defs.rs
+++ b/userspace/ksud/src/defs.rs
@@ -28,7 +28,7 @@ pub const MODULE_UPDATE_TMP_DIR: &str = concatcp!(ADB_DIR, "modules_update/");
 
 pub const SYSTEM_RW_DIR: &str = concatcp!(MODULE_DIR, ".rw/");
 
-pub const TEMP_DIR: &str = "/debug_ramdisk";
+pub const TEMP_DIR: &str = "/apex/debug_ramdisk";
 pub const MODULE_WEB_DIR: &str = "webroot";
 pub const MODULE_ACTION_SH: &str = "action.sh";
 pub const DISABLE_FILE_NAME: &str = "disable";

--- a/userspace/ksud/src/mount.rs
+++ b/userspace/ksud/src/mount.rs
@@ -11,6 +11,7 @@ use crate::defs::KSU_OVERLAY_SOURCE;
 use log::{info, warn};
 #[cfg(any(target_os = "linux", target_os = "android"))]
 use procfs::process::Process;
+use std::fs::create_dir_all;
 use std::path::Path;
 use std::path::PathBuf;
 
@@ -158,6 +159,7 @@ pub fn mount_overlayfs(
 #[cfg(any(target_os = "linux", target_os = "android"))]
 pub fn mount_tmpfs(dest: impl AsRef<Path>) -> Result<()> {
     info!("mount tmpfs on {}", dest.as_ref().display());
+    create_dir_all(dest.as_ref())?;
     let fs = fsopen("tmpfs", FsOpenFlags::FSOPEN_CLOEXEC)?;
     let fs = fs.as_fd();
     fsconfig_set_string(fs, "source", KSU_OVERLAY_SOURCE)?;


### PR DESCRIPTION
A shared mount point will create a new mounting peer group. It results in a new detection point, because after unmounting these mount points, gaps will appear in peer group IDs. One can check these gaps by the command
```
cat /proc/self/mountinfo | grep -Eo "master:.." | cut -d':' -f2 | sort | uniq
```

In Holmes V1.5.1, the above detection point is named as Evil Modification (04).