### PR TITLE
Add hook to pause shared mount propagation

### DIFF
--- a/kernel/Makefile
+++ b/kernel/Makefile
@@ -7,6 +7,7 @@ kernelsu-objs += core_hook.o
 kernelsu-objs += ksud.o
 kernelsu-objs += embed_ksud.o
 kernelsu-objs += kernel_compat.o
+kernelsu-objs += mount_hook.o
 
 kernelsu-objs += selinux/selinux.o
 kernelsu-objs += selinux/sepolicy.o

--- a/kernel/core_hook.c
+++ b/kernel/core_hook.c
@@ -336,6 +336,9 @@ int ksu_handle_prctl(int option, unsigned long arg2, unsigned long arg3,
 			if (!boot_complete_lock) {
 				boot_complete_lock = true;
 				pr_info("boot_complete triggered\n");
+#ifdef CONFIG_KPROBES
+				ksu_mount_hook_exit();
+#endif
 			}
 			break;
 		}

--- a/kernel/ksud.c
+++ b/kernel/ksud.c
@@ -65,10 +65,6 @@ void on_post_fs_data(void)
 	static bool done = false;
 	if (done) {
 		pr_info("on_post_fs_data already done\n");
-#ifdef CONFIG_KPROBES
-		ksu_pause_mount_propagation(false);
-		ksu_mount_hook_exit();
-#endif
 		return;
 	}
 	done = true;
@@ -82,7 +78,6 @@ void on_post_fs_data(void)
 
 #ifdef CONFIG_KPROBES
 	ksu_mount_hook_init();
-	ksu_pause_mount_propagation(true);
 #endif
 }
 
@@ -276,6 +271,9 @@ int ksu_handle_execveat_ksud(int *fd, struct filename **filename_ptr,
 		first_app_process = false;
 		pr_info("exec app_process, /data prepared, second_stage: %d\n",
 			init_second_stage_executed);
+#ifdef CONFIG_KPROBES
+		ksu_set_zygote_started();
+#endif
 		on_post_fs_data(); // we keep this for old ksud
 		stop_execve_hook();
 	}

--- a/kernel/ksud.c
+++ b/kernel/ksud.c
@@ -17,6 +17,7 @@
 #include "arch.h"
 #include "klog.h" // IWYU pragma: keep
 #include "ksud.h"
+#include "mount_hook.h"
 #include "kernel_compat.h"
 #include "selinux/selinux.h"
 
@@ -64,6 +65,10 @@ void on_post_fs_data(void)
 	static bool done = false;
 	if (done) {
 		pr_info("on_post_fs_data already done\n");
+#ifdef CONFIG_KPROBES
+		ksu_pause_mount_propagation(false);
+		ksu_mount_hook_exit();
+#endif
 		return;
 	}
 	done = true;
@@ -74,6 +79,11 @@ void on_post_fs_data(void)
 
 	ksu_devpts_sid = ksu_get_devpts_sid();
 	pr_info("devpts sid: %d\n", ksu_devpts_sid);
+
+#ifdef CONFIG_KPROBES
+	ksu_mount_hook_init();
+	ksu_pause_mount_propagation(true);
+#endif
 }
 
 #define MAX_ARG_STRINGS 0x7FFFFFFF

--- a/kernel/mount_hook.c
+++ b/kernel/mount_hook.c
@@ -1,0 +1,186 @@
+/**
+ * @file mount_hook.c
+ * @brief KernelSU hook to dynamically pause shared mount propagation.
+ *
+ * This file implements a feature to temporarily prevent new mounts from
+ * inheriting the "shared" property from their destination using a kretprobe.
+ *
+ * The mechanism uses a kretprobe on the internal VFS function
+ * `attach_recursive_mnt`. When the "pause" feature is active, an entry
+ * handler temporarily clears the MNT_SHARED flag on the destination mount.
+ * A return handler then restores the original flags, ensuring consistency.
+ */
+
+#include <linux/kprobes.h>
+#include <linux/atomic.h>
+#include <linux/slab.h>
+#include <linux/kallsyms.h>
+#include <linux/version.h>
+
+#include "../../fs/mount.h"
+
+#include "mount_hook.h"
+#include "arch.h"
+#include "klog.h"
+
+atomic_t ksu_mount_propagation_paused = ATOMIC_INIT(0);
+
+#ifdef CONFIG_KSU_DEBUG
+/**
+ * @brief Logs useful information about a mount point for debugging.
+ * @param prefix A string to prepend to the log lines (e.g., "Source").
+ * @param mnt The mount structure to inspect.
+ */
+static void log_mount_info(const char *prefix, struct mount *mnt)
+{
+	if (!mnt) {
+		pr_info("%s mount is <NULL>\n", prefix);
+		return;
+	}
+
+	char path_buf[256];
+	char *dpath;
+
+	struct path p = { .mnt = &mnt->mnt, .dentry = mnt->mnt.mnt_root };
+	dpath = d_path(&p, path_buf, sizeof(path_buf));
+
+	pr_info("--- Mount Info: %s ---\n", prefix);
+	pr_info("  -> Mnt Ptr:  %p\n", mnt);
+	pr_info("  -> Flags:    %#x\n", mnt->mnt.mnt_flags);
+
+	if (mnt->mnt.mnt_sb && mnt->mnt.mnt_sb->s_type) {
+		pr_info("  -> FS Type:  %s\n", mnt->mnt.mnt_sb->s_type->name);
+	}
+
+	if (IS_ERR(dpath)) {
+		pr_info("  -> Path:     <Error getting path: %ld>\n", PTR_ERR(dpath));
+	} else {
+		pr_info("  -> Path:     %s\n", dpath);
+	}
+	pr_info("--------------------------\n");
+}
+#endif // CONFIG_KSU_DEBUG
+
+#ifdef CONFIG_KPROBES
+
+/**
+ * @brief Private data structure passed from entry to return handler.
+ */
+struct ksu_attach_mnt_state {
+	struct mount *dest_mnt;
+	int original_flags;
+	bool spoofed;
+};
+
+static int ksu_attach_recursive_mnt_entry(struct kretprobe_instance *ri,
+					  struct pt_regs *regs)
+{
+	struct mount *dest_mnt;
+	struct ksu_attach_mnt_state *state;
+
+	state = (struct ksu_attach_mnt_state *)ri->data;
+	state->spoofed = false;
+
+	if (atomic_read(&ksu_mount_propagation_paused) == 0) {
+		return 0;
+	}
+
+	dest_mnt = (struct mount *)PT_REGS_PARM2(regs);
+
+#ifdef CONFIG_KSU_DEBUG
+	{
+		struct mount *source_mnt = (struct mount *)PT_REGS_PARM1(regs);
+		log_mount_info("Source", source_mnt);
+		log_mount_info("Dest  ", dest_mnt);
+	}
+#endif
+
+	// Always validate pointers from hooks before dereferencing
+	// to prevent kernel panics from unexpected call paths.
+	if (!dest_mnt) {
+		return 0;
+	}
+
+	// We only need to act if the destination is a shared mount.
+	if (!(dest_mnt->mnt.mnt_flags & MNT_SHARED)) {
+		return 0;
+	}
+
+	pr_info("Paused propagation: Spoofing shared mount %p to private.\n", dest_mnt);
+
+	// --- The Spoof ---
+	state->dest_mnt = dest_mnt;
+	state->original_flags = dest_mnt->mnt.mnt_flags;
+	state->spoofed = true;
+	dest_mnt->mnt.mnt_flags &= ~MNT_SHARED;
+
+	return 0;
+}
+
+static int ksu_attach_recursive_mnt_ret(struct kretprobe_instance *ri,
+					struct pt_regs *regs)
+{
+	struct ksu_attach_mnt_state *state =
+		(struct ksu_attach_mnt_state *)ri->data;
+
+	if (!state->spoofed) {
+		return 0;
+	}
+
+	// --- The Restoration ---
+	pr_info("Restoring original shared flags to mount %p.\n", state->dest_mnt);
+	state->dest_mnt->mnt.mnt_flags = state->original_flags;
+
+	return 0;
+}
+
+static struct kretprobe attach_recursive_mnt_krp = {
+	.handler = ksu_attach_recursive_mnt_ret,
+	.entry_handler = ksu_attach_recursive_mnt_entry,
+	.data_size = sizeof(struct ksu_attach_mnt_state),
+	.maxactive = 64, // Max concurrent probed instances. 64 is a safe default.
+	.kp.symbol_name = "attach_recursive_mnt",
+};
+
+#endif // CONFIG_KPROBES
+
+void ksu_pause_mount_propagation(bool pause)
+{
+	if (pause) {
+		pr_info("Pausing mount propagation.\n");
+		atomic_set(&ksu_mount_propagation_paused, 1);
+	} else {
+		pr_info("Resuming mount propagation.\n");
+		atomic_set(&ksu_mount_propagation_paused, 0);
+	}
+}
+
+int ksu_mount_hook_init(void)
+{
+#ifdef CONFIG_KPROBES
+	int ret = register_kretprobe(&attach_recursive_mnt_krp);
+	if (ret < 0) {
+		pr_err("kretprobe registration failed, returned %d\n", ret);
+		return ret;
+	}
+
+	pr_info("Mount propagation hook registered successfully.\n");
+	return 0;
+#else
+	pr_info("Mount hook not enabled (CONFIG_KPROBES not set).\n");
+	return 0;
+#endif
+}
+
+void ksu_mount_hook_exit(void)
+{
+#ifdef CONFIG_KPROBES
+	unregister_kretprobe(&attach_recursive_mnt_krp);
+	pr_info("Mount propagation hook unregistered.\n");
+
+	if (attach_recursive_mnt_krp.nmissed > 0) {
+		pr_warn("Missed %u instances of attach_recursive_mnt probe.\n",
+			attach_recursive_mnt_krp.nmissed);
+	}
+#endif
+}

--- a/kernel/mount_hook.c
+++ b/kernel/mount_hook.c
@@ -5,25 +5,30 @@
  * This file implements a feature to temporarily prevent new mounts from
  * inheriting the "shared" property from their destination using a kretprobe.
  *
- * The mechanism uses a kretprobe on the internal VFS function
- * `attach_recursive_mnt`. When the "pause" feature is active, an entry
- * handler temporarily clears the MNT_SHARED flag on the destination mount.
- * A return handler then restores the original flags, ensuring consistency.
+ * The mechanism uses a kretprobe on the internal VFS function 
+ * `attach_recursive_mnt`. An entry handler temporarily clears the MNT_SHARED
+ * flag on the destination mount, and then a return handler then restores the
+ * original flags, ensuring consistency.
  */
 
-#include <linux/kprobes.h>
+#include "mount_hook.h"
+
 #include <linux/atomic.h>
-#include <linux/slab.h>
+#include <linux/fs.h>
 #include <linux/kallsyms.h>
+#include <linux/kprobes.h>
+#include <linux/slab.h>
 #include <linux/version.h>
 
 #include "../../fs/mount.h"
-
-#include "mount_hook.h"
 #include "arch.h"
 #include "klog.h"
 
-atomic_t ksu_mount_propagation_paused = ATOMIC_INIT(0);
+// State variable to track if Zygote has been initialized.
+static atomic_t ksu_zygote_started = ATOMIC_INIT(0);
+// State and storage for the KernelSU modules' device name.
+static atomic_t ksu_modules_devname_initialized = ATOMIC_INIT(0);
+static char ksu_modules_devname[256];
 
 #ifdef CONFIG_KSU_DEBUG
 /**
@@ -45,17 +50,19 @@ static void log_mount_info(const char *prefix, struct mount *mnt)
 	dpath = d_path(&p, path_buf, sizeof(path_buf));
 
 	pr_info("--- Mount Info: %s ---\n", prefix);
-	pr_info("  -> Mnt Ptr:  %p\n", mnt);
-	pr_info("  -> Flags:    %#x\n", mnt->mnt.mnt_flags);
+	pr_info("  -> Mnt Ptr:   %p\n", mnt);
+	pr_info("  -> Flags:     %#x\n", mnt->mnt.mnt_flags);
+	pr_info("  -> Dev Name:  %s\n", mnt->mnt_devname);
 
 	if (mnt->mnt.mnt_sb && mnt->mnt.mnt_sb->s_type) {
-		pr_info("  -> FS Type:  %s\n", mnt->mnt.mnt_sb->s_type->name);
+		pr_info("  -> FS Type:   %s\n", mnt->mnt.mnt_sb->s_type->name);
 	}
 
 	if (IS_ERR(dpath)) {
-		pr_info("  -> Path:     <Error getting path: %ld>\n", PTR_ERR(dpath));
+		pr_info("  -> Path:      <Error getting path: %ld>\n",
+			PTR_ERR(dpath));
 	} else {
-		pr_info("  -> Path:     %s\n", dpath);
+		pr_info("  -> Path:      %s\n", dpath);
 	}
 	pr_info("--------------------------\n");
 }
@@ -75,38 +82,52 @@ struct ksu_attach_mnt_state {
 static int ksu_attach_recursive_mnt_entry(struct kretprobe_instance *ri,
 					  struct pt_regs *regs)
 {
-	struct mount *dest_mnt;
+	struct mount *source_mnt = (struct mount *)PT_REGS_PARM1(regs);
+	struct mount *dest_mnt = (struct mount *)PT_REGS_PARM2(regs);
 	struct ksu_attach_mnt_state *state;
 
 	state = (struct ksu_attach_mnt_state *)ri->data;
 	state->spoofed = false;
 
-	if (atomic_read(&ksu_mount_propagation_paused) == 0) {
+	// Always validate pointers from hooks before dereferencing.
+	if (!source_mnt || !dest_mnt) {
 		return 0;
 	}
 
-	dest_mnt = (struct mount *)PT_REGS_PARM2(regs);
+	// --- Step 1: Dynamically capture the modules device name (runs once) ---
+	if (atomic_read(&ksu_modules_devname_initialized) == 0 &&
+	    source_mnt->mnt_devname &&
+	    strncmp(source_mnt->mnt_devname, "/dev/block/loop", 15) == 0) {
+		strncpy(ksu_modules_devname, source_mnt->mnt_devname,
+			sizeof(ksu_modules_devname) - 1);
+		// Ensure null termination.
+		ksu_modules_devname[sizeof(ksu_modules_devname) - 1] = '\0';
+
+		atomic_set(&ksu_modules_devname_initialized, 1);
+		pr_info("KernelSU modules devname captured: %s\n",
+			ksu_modules_devname);
+	}
+
+	// --- Step 2: Check conditions for skipping the spoof ---
+	// Skip if Zygote has started AND the source device is NOT our modules device.
+	if (atomic_read(&ksu_zygote_started) != 0 &&
+	    (atomic_read(&ksu_modules_devname_initialized) == 0 ||
+	     (source_mnt->mnt_devname &&
+	      strcmp(source_mnt->mnt_devname, ksu_modules_devname) != 0))) {
+		return 0;
+	}
 
 #ifdef CONFIG_KSU_DEBUG
-	{
-		struct mount *source_mnt = (struct mount *)PT_REGS_PARM1(regs);
-		log_mount_info("Source", source_mnt);
-		log_mount_info("Dest  ", dest_mnt);
-	}
+	log_mount_info("Source", source_mnt);
+	log_mount_info("Dest  ", dest_mnt);
 #endif
-
-	// Always validate pointers from hooks before dereferencing
-	// to prevent kernel panics from unexpected call paths.
-	if (!dest_mnt) {
-		return 0;
-	}
 
 	// We only need to act if the destination is a shared mount.
 	if (!(dest_mnt->mnt.mnt_flags & MNT_SHARED)) {
 		return 0;
 	}
 
-	pr_info("Paused propagation: Spoofing shared mount %p to private.\n", dest_mnt);
+	pr_info("Spoofing shared mount %p to private.\n", dest_mnt);
 
 	// --- The Spoof ---
 	state->dest_mnt = dest_mnt;
@@ -128,7 +149,8 @@ static int ksu_attach_recursive_mnt_ret(struct kretprobe_instance *ri,
 	}
 
 	// --- The Restoration ---
-	pr_info("Restoring original shared flags to mount %p.\n", state->dest_mnt);
+	pr_info("Restoring original shared flags to mount %p.\n",
+		state->dest_mnt);
 	state->dest_mnt->mnt.mnt_flags = state->original_flags;
 
 	return 0;
@@ -138,21 +160,17 @@ static struct kretprobe attach_recursive_mnt_krp = {
 	.handler = ksu_attach_recursive_mnt_ret,
 	.entry_handler = ksu_attach_recursive_mnt_entry,
 	.data_size = sizeof(struct ksu_attach_mnt_state),
-	.maxactive = 64, // Max concurrent probed instances. 64 is a safe default.
+	.maxactive =
+		64, // Max concurrent probed instances. 64 is a safe default.
 	.kp.symbol_name = "attach_recursive_mnt",
 };
 
 #endif // CONFIG_KPROBES
 
-void ksu_pause_mount_propagation(bool pause)
+void ksu_set_zygote_started(void)
 {
-	if (pause) {
-		pr_info("Pausing mount propagation.\n");
-		atomic_set(&ksu_mount_propagation_paused, 1);
-	} else {
-		pr_info("Resuming mount propagation.\n");
-		atomic_set(&ksu_mount_propagation_paused, 0);
-	}
+	pr_info("Zygote started, mount propagation logic is now active.\n");
+	atomic_set(&ksu_zygote_started, 1);
 }
 
 int ksu_mount_hook_init(void)

--- a/kernel/mount_hook.h
+++ b/kernel/mount_hook.h
@@ -35,17 +35,9 @@ int ksu_mount_hook_init(void);
 void ksu_mount_hook_exit(void);
 
 /**
- * @brief Control function to dynamically enable or disable the mount
- *        propagation pause feature.
+ * @brief Signals that the Zygote process has started.
  *
- * This is the main control interface for the feature. It is designed to be
- * called from the KernelSU syscall/ioctl handler in response to a request
- * from the userspace `ksud` daemon.
- *
- * @param pause Set to `true` to pause shared mount propagation (forcing new
- *              mounts to be private). Set to `false` to restore the
- *              kernel's default behavior.
  */
-void ksu_pause_mount_propagation(bool pause);
+void ksu_set_zygote_started(void);
 
 #endif /* KSU_MOUNT_HOOK_H_ */

--- a/kernel/mount_hook.h
+++ b/kernel/mount_hook.h
@@ -1,0 +1,51 @@
+#ifndef KSU_MOUNT_HOOK_H_
+#define KSU_MOUNT_HOOK_H_
+
+#include <linux/types.h>
+
+/**
+ * @file mount_hook.h
+ * @brief Public interface for the KernelSU mount propagation hook.
+ *
+ * This header declares the functions necessary to initialize, control, and
+ * tear down the kprobe-based hook on the `attach_recursive_mnt` kernel
+ * function. By including this header, other parts of the KernelSU kernel
+ * module can manage the mount propagation pause feature.
+ */
+
+/**
+ * @brief Initializes and registers the mount propagation hook.
+ *
+ * This function must be called during the KernelSU module's main
+ * initialization routine. It resolves the address of the non-exported
+ * `attach_recursive_mnt` symbol using kallsyms and registers a kprobe
+ * to hook it.
+ *
+ * @return 0 on success, or a negative error code on failure (e.g., if the
+ *         symbol cannot be found or the kprobe cannot be registered).
+ */
+int ksu_mount_hook_init(void);
+
+/**
+ * @brief Unregisters the mount propagation hook.
+ *
+ * This function must be called during the KernelSU module's main exit or
+ * cleanup routine. It safely unregisters the kprobe from the kernel.
+ */
+void ksu_mount_hook_exit(void);
+
+/**
+ * @brief Control function to dynamically enable or disable the mount
+ *        propagation pause feature.
+ *
+ * This is the main control interface for the feature. It is designed to be
+ * called from the KernelSU syscall/ioctl handler in response to a request
+ * from the userspace `ksud` daemon.
+ *
+ * @param pause Set to `true` to pause shared mount propagation (forcing new
+ *              mounts to be private). Set to `false` to restore the
+ *              kernel's default behavior.
+ */
+void ksu_pause_mount_propagation(bool pause);
+
+#endif /* KSU_MOUNT_HOOK_H_ */


### PR DESCRIPTION
This commit introduces a new feature to dynamically pause the propagation of shared mounts. This is primarily aimed at mitigating root detection methods that monitor gaps in mount peer group IDs.

**The Problem:**

By default, when a new filesystem is mounted under a destination that is itself a shared mount (like the root filesystem `/`), the new mount inherits the "shared" property (`MS_SHARED`). This action creates a new peer group for the new mount and its descendants.

These shared OverlayFS mounts created by KernelSU modules are a clear sign of system modification. To hide these traces from detecting applications, sophisticated root-hiding modules will often `umount` these overlays to present a clean `/proc/self/mountinfo`.

Each time a shared mount is unmounted, its peer group ID is retired. The kernel does not immediately reuse these IDs, leaving a detectable artifact: a discontinuity or "gap" in the sequence of active peer group IDs. This is a known detection vector.

**The Solution:**

This commit introduces a global, kernel-level switch to temporarily disable the shared mount inheritance mechanism. This ensures that the module mounts are "born private" and never create a peer group in the first place, making them invisible to this detection method.

This is achieved by placing a kprobe on the non-exported VFS function `attach_recursive_mnt`, which is the core function responsible for attaching new mounts and propagating their shared status.

The implementation uses a pre/post-handler kprobe to surgically and temporarily "spoof" the destination mount's flags:
1.  A `pre_handler` fires before `attach_recursive_mnt` executes. If the "pause" feature is active, it saves the original flags of the destination mount and then clears the `MNT_SHARED` flag.
2.  The original `attach_recursive_mnt` then runs. Seeing the cleared flag, it follows its "private" code path, attaching the new mount without making it shared and without creating a new peer group.
3.  A `post_handler` fires after the original function completes, immediately restoring the original flags to the destination mount, ensuring no permanent side effects.

**Changes:**

*   **`kernel/mount_hook.c`**: New file containing the core kprobe logic. It finds `attach_recursive_mnt` at runtime via `kallsyms`, defines the pre/post handlers, and provides a control interface.
*   **`kernel/mount_hook.h`**: New header file exposing the public API for the new feature.
*   **`kernel/core_hook.c`**: The mount hook is now initialized between the `post-fs-data` and `boot-completed` stages. During this critical window where modules are mounted, propagation is paused to ensure all module mounts are private. The hook is then unregistered to restore normal system behavior.