### PR TITLE
Group app list by user profile

### DIFF
--- a/manager/app/src/main/java/me/weishu/kernelsu/ui/screen/AppProfile.kt
+++ b/manager/app/src/main/java/me/weishu/kernelsu/ui/screen/AppProfile.kt
@@ -133,10 +133,8 @@ fun AppProfileScreen(
                     appLabel = appInfo.label,
                     appIcon = {
                         AppIconImage(
-                            packageInfo = appInfo.packageInfo,
-                            label = appInfo.label,
-                            modifier = Modifier
-                                .size(60.dp)
+                            app = appInfo,
+                            modifier = Modifier.size(60.dp)
                         )
                     },
                     profile = profile,

--- a/manager/app/src/main/java/me/weishu/kernelsu/ui/screen/SuperUser.kt
+++ b/manager/app/src/main/java/me/weishu/kernelsu/ui/screen/SuperUser.kt
@@ -22,6 +22,7 @@ import androidx.compose.foundation.layout.calculateEndPadding
 import androidx.compose.foundation.layout.calculateStartPadding
 import androidx.compose.foundation.layout.displayCutout
 import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.ime
 import androidx.compose.foundation.layout.only
@@ -82,6 +83,7 @@ import top.yukonga.miuix.kmp.icon.MiuixIcons
 import top.yukonga.miuix.kmp.icon.icons.basic.ArrowRight
 import top.yukonga.miuix.kmp.icon.icons.useful.ImmersionMore
 import top.yukonga.miuix.kmp.theme.MiuixTheme.colorScheme
+import top.yukonga.miuix.kmp.theme.MiuixTheme.textStyles
 import top.yukonga.miuix.kmp.utils.PressFeedbackType
 import top.yukonga.miuix.kmp.utils.getWindowSize
 import top.yukonga.miuix.kmp.utils.overScrollVertical
@@ -99,7 +101,7 @@ fun SuperUserPager(
     val searchStatus by viewModel.searchStatus
 
     LaunchedEffect(navigator) {
-        if (viewModel.appList.value.isEmpty() || viewModel.searchResults.value.isEmpty()) {
+        if (viewModel.appList.value.isEmpty()) {
             viewModel.fetchAppList()
         }
     }
@@ -269,10 +271,15 @@ fun SuperUserPager(
                         ),
                         overscrollEffect = null,
                     ) {
-                        items(viewModel.appList.value, key = { it.packageName + it.uid }) { app ->
-                            AppItem(app) {
-                                navigator.navigate(AppProfileScreenDestination(app)) {
-                                    launchSingleTop = true
+                        val appList = viewModel.appList.value
+                        items(appList, key = { it.packageName + it.uid }) { item ->
+                            if (item.packageName.startsWith("header.")) {
+                                ProfileHeader(name = item.label)
+                            } else {
+                                AppItem(item) {
+                                    navigator.navigate(AppProfileScreenDestination(item)) {
+                                        launchSingleTop = true
+                                    }
                                 }
                             }
                         }
@@ -284,6 +291,19 @@ fun SuperUserPager(
             }
         }
     }
+}
+
+@Composable
+private fun ProfileHeader(name: String) {
+    Text(
+        text = name,
+        style = textStyles.title2,
+        color = colorScheme.primary,
+        fontWeight = FontWeight.Bold,
+        modifier = Modifier
+            .fillMaxWidth()
+            .padding(start = 16.dp, end = 16.dp, top = 12.dp, bottom = 18.dp)
+    )
 }
 
 @Composable
@@ -306,8 +326,7 @@ private fun AppItem(
             summary = app.packageName,
             leftAction = {
                 AppIconImage(
-                    packageInfo = app.packageInfo,
-                    label = app.label,
+                    app = app,
                     modifier = Modifier
                         .padding(end = 12.dp)
                         .size(48.dp)


### PR DESCRIPTION
Previously, the app list displayed applications from all user profiles (e.g., main, private space) in a single, flat list, making it impossible for users to distinguish between them.

This commit resolves the issue by introducing profile-aware grouping and badging:

- Enriches the `AppInfo` data model with the `UserHandle` to associate each app with its profile.
- Updates the `SuperUserViewModel` to group fetched applications by their `UserHandle`, ensuring the main profile's apps appear first.
- Introduces profile headers (e.g., "Main Profile", "Private Profile") into the `LazyColumn` for clear visual separation. Headers are intelligently omitted on single-user systems.
- Modifies `AppIconImage` to use `PackageManager.getUserBadgedIcon()`. This automatically applies the correct system badge (e.g., a lock icon) to apps from non-primary profiles, enhancing UX consistency with the Android system.